### PR TITLE
nori のバージョンアップでString#snakecase が無くなったため、StringUtils#snakecaseに変更

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,39 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+        
+    - name: Install dependencies
+      run: bundle install
+      
+    - name: Run tests
+      run: bundle exec rspec
+      
+    - name: Build gem
+      run: gem build soapforce.gemspec
+      
+    - name: Publish to GitHub Packages
+      run: |
+        mkdir -p ~/.gem
+        echo "---" > ~/.gem/credentials
+        echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
+        chmod 0600 ~/.gem/credentials
+        gem push --key github --host https://rubygems.pkg.github.com/${{ github.repository_owner }} *.gem
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/soapforce.rb
+++ b/lib/soapforce.rb
@@ -8,6 +8,7 @@ require "soapforce/client"
 require "soapforce/result"
 require "soapforce/query_result"
 require "soapforce/sobject"
+require "soapforce/string_utils"
 
 module Soapforce
 

--- a/lib/soapforce/client.rb
+++ b/lib/soapforce/client.rb
@@ -38,7 +38,7 @@ module Soapforce
         @response_tags = lambda { |key| key }
       else
         @tag_style = :snakecase
-        @response_tags = lambda { |key| key.snakecase.to_sym }
+        @response_tags = lambda { |key| ::Soapforce::StringUtils.snakecase(key).to_sym }
       end
 
       # Override optional Savon attributes
@@ -586,7 +586,7 @@ module Soapforce
 
     def key_name(key)
       if @tag_style == :snakecase
-        key.is_a?(Symbol) ? key : key.snakecase.to_sym
+        key.is_a?(Symbol) ? key : ::Soapforce::StringUtils.snakecase(key).to_sym
       else
         if key.to_s.include?('_')
           camel_key = key.to_s.gsub(/\_(\w{1})/) {|cap| cap[1].upcase }

--- a/lib/soapforce/query_result.rb
+++ b/lib/soapforce/query_result.rb
@@ -61,7 +61,7 @@ module Soapforce
 
     def key_name(key)
       if @key_type == :symbol
-        key.is_a?(String) ? key.snakecase.to_sym : key
+        key.is_a?(String) ? ::Soapforce::StringUtils.snakecase(key).to_sym : key
       else
         key.to_s
       end

--- a/lib/soapforce/result.rb
+++ b/lib/soapforce/result.rb
@@ -28,7 +28,7 @@ module Soapforce
         elsif @raw_hash.key?(index.to_sym)
           @raw_hash[index.to_sym]
         else
-          @raw_hash[index.snakecase.to_sym]
+          @raw_hash[::Soapforce::StringUtils.snakecase(index).to_sym]
         end
       end
     end

--- a/lib/soapforce/sobject.rb
+++ b/lib/soapforce/sobject.rb
@@ -52,7 +52,7 @@ module Soapforce
       end
 
       if string_method =~ /[A-Z+]/
-        string_method = string_method.snakecase
+        string_method = ::Soapforce::StringUtils.snakecase(string_method)
       end
 
       index = string_method.downcase.to_sym

--- a/lib/soapforce/string_utils.rb
+++ b/lib/soapforce/string_utils.rb
@@ -1,0 +1,21 @@
+module Soapforce
+  module StringUtils
+    # Converts a string to snake case.
+    #
+    # @param inputstring [String] The string to be converted to snake case.
+    # @return [String] A copy of the input string converted to snake case.
+    #
+    # copy from nori
+    # ref: https://github.com/savonrb/nori/pull/102/files
+    def self.snakecase(inputstring)
+      str = inputstring.dup
+      str.gsub!(/::/, '/')
+      str.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+      str.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+      str.tr!(".", "_")
+      str.tr!("-", "_")
+      str.downcase!
+      str
+    end
+  end
+end

--- a/lib/soapforce/version.rb
+++ b/lib/soapforce/version.rb
@@ -1,3 +1,3 @@
 module Soapforce
-  VERSION = "0.8.0"
+  VERSION = "0.8.0.trocco.0.0.1"
 end

--- a/soapforce.gemspec
+++ b/soapforce.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "savon", ">= 2.3.0", '< 3.0.0'
-  spec.add_runtime_dependency "nori", "2.6.0"
 
   spec.add_development_dependency 'rspec', '>= 2.14.0', '< 4.0.0'
   spec.add_development_dependency 'webmock', '>=2.3.2'


### PR DESCRIPTION
nori のバージョンアップでString#snakecase が無くなったため、noriからStringUtils#snakecaseを移植し変更https://github.com/savonrb/nori/pull/102/files

underscoreはruby標準ではなく、ActiveSupportでした。
https://apidock.com/rails/String/underscore
